### PR TITLE
add docker workflow and refactored Dockerfile

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -1,0 +1,35 @@
+name: Publish Docker image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+      
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: meowcoinlol/meowcoin-core
+          tags: |
+            type=ref,event=tag
+      
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,6 @@ RUN apt-get update && \
 	libzmq3-dev libminiupnpc-dev libdb4.8-dev libdb4.8++-dev && \
 	apt-get clean
 
-
 #Build Meowcoin from source
 COPY . /home/meowcoin/build/Meowcoin/
 WORKDIR /home/meowcoin/build/Meowcoin
@@ -41,20 +40,8 @@ RUN ./autogen.sh && ./configure --disable-tests --with-gui=no && make
 
 FROM base AS final
 
-#Add our service account user
-RUN useradd -ms /bin/bash meowcoin && \
-	mkdir /var/lib/meowcoin && \
-	chown meowcoin:meowcoin /var/lib/meowcoin && \
-	ln -s /var/lib/meowcoin /home/meowcoin/.meowcoin && \
-	chown -h meowcoin:meowcoin /home/meowcoin/.meowcoin
-
-VOLUME /var/lib/meowcoin
-
 #Copy the compiled binaries from the build
 COPY --from=build /home/meowcoin/build/Meowcoin/src/meowcoind /usr/local/bin/meowcoind
 COPY --from=build /home/meowcoin/build/Meowcoin/src/meowcoin-cli /usr/local/bin/meowcoin-cli
 
-WORKDIR /home/meowcoin
-USER meowcoin
-
-CMD /usr/local/bin/meowcoind -datadir=/var/lib/meowcoin -printtoconsole -onlynet=ipv4
+ENTRYPOINT ["meowcoind", "-printtoconsole", "-onlynet=ipv4"]


### PR DESCRIPTION
Changes:
- Made `autogen.sh` and `share/genbuild.sh` executable with git index (I see another [PR #1](https://github.com/JustAResearcher/Meowcoin/pull/1) to make them executable in the Dockerfile but that isn't as clean)
- Added `build-and-publish.yaml`. workflow to build Docker image on published releases
 - Backed up current Dockerfile as Dockerfile.bak
- Refactored the Dockerfile to 
   - Run meowcoind as an `ENTRYPOINT` allowing more customization of container image by user
   - Removed unnecessary build steps